### PR TITLE
9 add semantic versioning fix2

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           git add charts/kafka-schema-operator/
           git commit -m "AUTOMATED: Updated helm version to ${{ steps.tag_version.outputs.new_version }}"
-          git push origin HEAD:refs/tags/v{{ steps.tag_version.outputs.new_version }}
+          git push origin HEAD:refs/tags/v${{ steps.tag_version.outputs.new_version }}
 
 #
 #      - name: Package and release Helm Chart

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -74,17 +74,17 @@ jobs:
 #        env:
 #          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
       - name: Push updated helm version to git repo
         run: |
           git add charts/kafka-schema-operator/
-          git commit -m "Updated helm version to ${{ steps.tag_version.outputs.new_version }}"
+          git commit -m "AUTOMATED: Updated helm version to ${{ steps.tag_version.outputs.new_version }}"
           git push origin HEAD:refs/tags/v{{ steps.tag_version.outputs.new_version }}
-       
 
-#      - name: Configure Git
-#        run: |
-#          git config user.name "$GITHUB_ACTOR"
-#          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 #
 #      - name: Package and release Helm Chart
 #        uses: helm/chart-releaser-action@v1.6.0

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -35,13 +35,14 @@ jobs:
       - name: Build
         run: make build
 
-      - name: Bump version and push tag
+      - name: Calculate new version tag (dry-run)
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: "master"
           tag_prefix: v
+          dry_run: 'true'
 
 #      - name: Log in to Docker Hub
 #        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
@@ -69,11 +70,6 @@ jobs:
           sed -i 's/version: .*/version: ${{ steps.tag_version.outputs.new_version }}/g' charts/kafka-schema-operator/Chart.yaml
           sed -i 's/version: .*/version: v${{ steps.tag_version.outputs.new_version }}/g' charts/kafka-schema-operator/values.yaml
 
-#      - name: Install Helm
-#        uses: azure/setup-helm@v3
-#        env:
-#          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
@@ -84,7 +80,21 @@ jobs:
           git pull --tags
           git add charts/kafka-schema-operator/
           git commit -m "AUTOMATED: Updated helm version to ${{ steps.tag_version.outputs.new_version }}"
-          git push origin HEAD:refs/tags/v${{ steps.tag_version.outputs.new_version }}
+#          git push origin HEAD:refs/tags/v${{ steps.tag_version.outputs.new_version }}
+
+      - name: Bump version and push tag
+        id: tag_push
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_branches: "master"
+          tag_prefix: v
+
+#      - name: Install Helm
+#        uses: azure/setup-helm@v3
+#        env:
+#          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
 
 #
 #      - name: Package and release Helm Chart

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -80,15 +80,15 @@ jobs:
           git pull --tags
           git add charts/kafka-schema-operator/
           git commit -m "AUTOMATED: Updated helm version to ${{ steps.tag_version.outputs.new_version }}"
-#          git push origin HEAD:refs/tags/v${{ steps.tag_version.outputs.new_version }}
+          git push origin HEAD:refs/tags/v${{ steps.tag_version.outputs.new_version }}
 
-      - name: Bump version and push tag
-        id: tag_push
-        uses: mathieudutour/github-tag-action@v6.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          release_branches: "master"
-          tag_prefix: v
+#      - name: Bump version and push tag
+#        id: tag_push
+#        uses: mathieudutour/github-tag-action@v6.2
+#        with:
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          release_branches: "master"
+#          tag_prefix: v
 
 #      - name: Install Helm
 #        uses: azure/setup-helm@v3

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 9-add-semantic-versioning-fix2
 
 jobs:
   build:
@@ -42,51 +43,55 @@ jobs:
           release_branches: "master"
           tag_prefix: v
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: tomekincubly/kafka-schema-operator
-
-      - name: Build and push Docker
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: tomekincubly/kafka-schema-operator:${{ steps.tag_version.outputs.new_tag }}
-          labels: ${{ steps.meta.outputs.labels }}
+#      - name: Log in to Docker Hub
+#        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#
+#      - name: Extract Docker metadata
+#        id: meta
+#        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+#        with:
+#          images: tomekincubly/kafka-schema-operator
+#
+#      - name: Build and push Docker
+#        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+#        with:
+#          context: .
+#          file: ./Dockerfile
+#          push: true
+#          tags: tomekincubly/kafka-schema-operator:${{ steps.tag_version.outputs.new_tag }}
+#          labels: ${{ steps.meta.outputs.labels }}
 
       - name: Update helm version
         run: |
           sed -i 's/version: .*/version: ${{ steps.tag_version.outputs.new_version }}/g' charts/kafka-schema-operator/Chart.yaml
           sed -i 's/version: .*/version: v${{ steps.tag_version.outputs.new_version }}/g' charts/kafka-schema-operator/values.yaml
 
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+#      - name: Install Helm
+#        uses: azure/setup-helm@v3
+#        env:
+#          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Push updated helm version to git repo
-        uses: stefanzweifel/git-auto-commit-action@v5
-
-      - name: Configure Git
         run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add charts/kafka-schema-operator/
+          git commit -m "Updated helm version to ${{ steps.tag_version.outputs.new_version }}"
+          git push origin HEAD:refs/tags/v{{ steps.tag_version.outputs.new_version }}
+       
 
-      - name: Package and release Helm Chart
-        uses: helm/chart-releaser-action@v1.6.0
-        with:
-          packages_with_index: true
-          pages_branch: "gh-pages"
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+#      - name: Configure Git
+#        run: |
+#          git config user.name "$GITHUB_ACTOR"
+#          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+#
+#      - name: Package and release Helm Chart
+#        uses: helm/chart-releaser-action@v1.6.0
+#        with:
+#          packages_with_index: true
+#          pages_branch: "gh-pages"
+#        env:
+#          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
 

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - 9-add-semantic-versioning-fix2
 
 jobs:
   build:
@@ -44,26 +43,26 @@ jobs:
           tag_prefix: v
           dry_run: 'true'
 
-#      - name: Log in to Docker Hub
-#        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
-#
-#      - name: Extract Docker metadata
-#        id: meta
-#        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-#        with:
-#          images: tomekincubly/kafka-schema-operator
-#
-#      - name: Build and push Docker
-#        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
-#        with:
-#          context: .
-#          file: ./Dockerfile
-#          push: true
-#          tags: tomekincubly/kafka-schema-operator:${{ steps.tag_version.outputs.new_tag }}
-#          labels: ${{ steps.meta.outputs.labels }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: tomekincubly/kafka-schema-operator
+
+      - name: Build and push Docker
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: tomekincubly/kafka-schema-operator:${{ steps.tag_version.outputs.new_tag }}
+          labels: ${{ steps.meta.outputs.labels }}
 
       - name: Update helm version
         run: |
@@ -75,34 +74,24 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Push updated helm version to git repo
+      - name: Push updated helm version and tag to git repo
         run: |
           git pull --tags
           git add charts/kafka-schema-operator/
           git commit -m "AUTOMATED: Updated helm version to ${{ steps.tag_version.outputs.new_version }}"
           git push origin HEAD:refs/tags/v${{ steps.tag_version.outputs.new_version }}
 
-#      - name: Bump version and push tag
-#        id: tag_push
-#        uses: mathieudutour/github-tag-action@v6.2
-#        with:
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          release_branches: "master"
-#          tag_prefix: v
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
-#      - name: Install Helm
-#        uses: azure/setup-helm@v3
-#        env:
-#          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
-
-#
-#      - name: Package and release Helm Chart
-#        uses: helm/chart-releaser-action@v1.6.0
-#        with:
-#          packages_with_index: true
-#          pages_branch: "gh-pages"
-#        env:
-#          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Package and release Helm Chart
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          packages_with_index: true
+          pages_branch: "gh-pages"
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
 

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -81,6 +81,7 @@ jobs:
 
       - name: Push updated helm version to git repo
         run: |
+          git pull --tags
           git add charts/kafka-schema-operator/
           git commit -m "AUTOMATED: Updated helm version to ${{ steps.tag_version.outputs.new_version }}"
           git push origin HEAD:refs/tags/v${{ steps.tag_version.outputs.new_version }}

--- a/charts/kafka-schema-operator/Chart.yaml
+++ b/charts/kafka-schema-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kafka-schema-operator
 description: Operator to maintain kafka schemas via CRD
 type: application
-version: 1.0.5
+version: 0.0.0 #TO BE UPDATED BY CI
 appVersion: "1.0.0"

--- a/charts/kafka-schema-operator/values.yaml
+++ b/charts/kafka-schema-operator/values.yaml
@@ -2,7 +2,7 @@ operator:
   pullPolicy: IfNotPresent
   replicas: 1
   image: tomekincubly/kafka-schema-operator
-  version: v1.0.5
+  version: 0.0.0 #TO BE UPDATED BY CI
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
Removed step in workflow that commits update helm version to git repo.
Updated helm version is now pushed only under release tag.