### PR TITLE
feat: additional labels and annotations from values file

### DIFF
--- a/charts/kafka-schema-operator/templates/deployment.yaml
+++ b/charts/kafka-schema-operator/templates/deployment.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes.labels" . | nindent 4 }}
+    {{- with .Values.deploymentLabels }}
+    {{-  toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.deploymentAnnotations }}
+    {{-  toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.operator.replicas }}
   selector:
@@ -13,7 +20,14 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "kubernetes.selectorLabels" . | nindent 8 }}
+        {{- include "kubernetes.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{-  toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- with .Values.podAnnotations }}
+        {{-  toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: "{{ .Release.Name }}-service-account"
       containers:

--- a/charts/kafka-schema-operator/values.yaml
+++ b/charts/kafka-schema-operator/values.yaml
@@ -30,3 +30,8 @@ defaultNormalize: false
 # Negative value - don't requeue (disable reconciliation loop)
 # Zero - requeue with exponential backoff
 requeueDelay: 1m
+
+deploymentLabels: {}
+deploymentAnnotations: {}
+podLabels: {}
+podAnnotations: {}


### PR DESCRIPTION
It is now possible to inject your custom deployment and pod labels and annotations through values file. New values:

```
deploymentLabels: {}
deploymentAnnotations: {}
podLabels: {}
podAnnotations: {}
```

Also, I've fixed "default" pod labels - we're now using kubernetes.labels instead of kubernetes.selectorLabels